### PR TITLE
コレクションリスト内の余白調整

### DIFF
--- a/src/common.css
+++ b/src/common.css
@@ -118,6 +118,7 @@ button:hover {
   display: flex;
   justify-content: space-between;
   flex-direction: column;
+  row-gap: 6px;
   min-width: 600px;
   height: 100%;
   padding: 12px 18px;
@@ -163,7 +164,6 @@ button:hover {
 .top-nft__bottom {
   display: flex;
   justify-content: space-between;
-  margin-top: 6px;
   font-size: 14px;
 }
 .top-nft__tag {


### PR DESCRIPTION
コレクションのボタンと画像がくっついちゃうの改善
<img width="623" alt="image" src="https://user-images.githubusercontent.com/706137/216975362-c57b1ba6-c3c1-4e13-b1de-d9e8d86747d4.png">
